### PR TITLE
Fix docker build gcc error in dvd-diff action

### DIFF
--- a/.github/actions/dvc-diff/Dockerfile
+++ b/.github/actions/dvc-diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.9
 
 RUN pip install dvc
 


### PR DESCRIPTION
This should fix the problem with the missing `gcc` dependency building the dvc.diff action docker image.