### PR TITLE
Fix problem with dvd diff not using git refs

### DIFF
--- a/.github/workflows/gold-drawings-processing.yml
+++ b/.github/workflows/gold-drawings-processing.yml
@@ -35,8 +35,8 @@ jobs:
           #git status
           git show-ref
           #git log --oneline
-          echo "git diff origin/${{ github.base_ref }} HEAD"
-          git diff origin/${{ github.base_ref }} HEAD
+          echo "git diff origin/${{ github.base_ref }} ${{ github.sha }}"
+          git diff origin/${{ github.base_ref }} ${{ github.sha }}
 
       - name: DVC diff
         id: dvc-diff
@@ -44,7 +44,7 @@ jobs:
         env:
           DVC_REPO_DIR: ${{ github.workspace }}
           PREVIOUS_REF: "origin/${{ github.base_ref }}"
-          CURRENT_REF: HEAD
+          CURRENT_REF: ${{ github.sha }}
 
       - name: Debug diff ouput
         run: |


### PR DESCRIPTION
I'm testing if using git ref instead of branch name will fix the problem with DVD diff not working with forks.