### PR TITLE
Trigger import workflow on website on push event in main branch

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -1,0 +1,19 @@
+name: Update website
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update-website:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Invoke workflow on website repository
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Import Base images from remote media library
+          repo: Nautilus-Cyberneering/chinese-ideographs-website
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          inputs: "{ \"library_sha\": \"${{ github.sha }}\" }"


### PR DESCRIPTION
When there is a new commit in the `main` branch of the library (this repo) we trigger manually a workflow on the website [project](https://github.com/Nautilus-Cyberneering/chinese-ideographs-website).

The workflow is the [import-base-images.yml](https://github.com/Nautilus-Cyberneering/chinese-ideographs-website/blob/main/.github/workflows/import-base-images.yml) workflow which imports Base image from the dvc storage.